### PR TITLE
Replace PostgreSQL sequence table locks with advisory locks

### DIFF
--- a/lib/sequenced/generator.rb
+++ b/lib/sequenced/generator.rb
@@ -1,3 +1,6 @@
+require "digest"
+require "json"
+
 module Sequenced
   class Generator
     attr_reader :record, :scope, :column, :table, :start_at, :skip
@@ -14,7 +17,7 @@ module Sequenced
     def set
       return if skip? || id_set?
 
-      lock_table
+      lock_sequence
       record.send(:"#{column}=", next_id)
     end
 
@@ -39,7 +42,7 @@ module Sequenced
     end
 
     def unique?(id)
-      build_scope(*scope) do
+      build_scope do
         rel = base_relation
         rel = rel.where.not(record.class.primary_key => record.id) if record.persisted?
         rel.where("#{table}.#{column}" => id)
@@ -48,10 +51,11 @@ module Sequenced
 
   private
 
-    def lock_table
-      if postgresql?
-        record.class.connection.execute("LOCK TABLE #{record.class.table_name} IN EXCLUSIVE MODE")
-      end
+    def lock_sequence
+      return unless postgresql?
+
+      key1, key2 = advisory_lock_keys
+      record.class.connection.execute("SELECT pg_advisory_xact_lock(#{key1}, #{key2})")
     end
 
     def postgresql?
@@ -64,25 +68,57 @@ module Sequenced
     end
 
     def find_last_record
-      build_scope(*scope) do
+      build_scope do
         base_relation
           .where("#{table}.#{column} IS NOT NULL")
           .order("#{table}.#{column} DESC")
       end.first
     end
 
-    def build_scope(*columns)
+    def advisory_lock_keys
+      Digest::SHA256.digest(lock_identity).unpack("l>l>")
+    end
+
+    def lock_identity
+      JSON.generate([
+        "sequenced",
+        table.to_s,
+        column.to_s,
+        resolved_scope_pairs
+      ])
+    end
+
+    def resolved_scope_pairs
+      scope_columns.map do |scope_column|
+        [scope_column.to_s, scope_value(scope_column)]
+      end
+    end
+
+    def build_scope
       rel = yield
-      columns.each do |c|
-        if c.to_s.include? '.'
-          accessor, column = c.split('.')
+      scope_columns.each do |scope_column|
+        if scope_column.to_s.include? "."
+          accessor, column = scope_column.to_s.split(".", 2)
           table = record.class.reflections[accessor].table_name
-          rel = rel.joins(accessor.to_sym).includes(accessor.to_sym).where("#{table}.#{column}" => record.send(column))
+          rel = rel.joins(accessor.to_sym).includes(accessor.to_sym).where("#{table}.#{column}" => scope_value(scope_column))
         else
-          rel = rel.where(c => record.send(c))
+          rel = rel.where(scope_column => scope_value(scope_column))
         end
       end
       rel
+    end
+
+    def scope_columns
+      Array(scope).compact
+    end
+
+    def scope_value(scope_column)
+      if scope_column.to_s.include? "."
+        _accessor, column_name = scope_column.to_s.split(".", 2)
+        record.send(column_name)
+      else
+        record.send(scope_column)
+      end
     end
 
     def max(*values)

--- a/test/concurrency_test.rb
+++ b/test/concurrency_test.rb
@@ -16,36 +16,55 @@ require 'test_helper'
 #   Zombie       - STI, inherits from Monster
 #   Werewolf     - STI, inherits from Monster
 
-#   ConcurrentBadger - scope: :concurrent_burrow_id,
+#   ConcurrentBadger - scope: :burrow_id,
 #                      NOT NULL constraint on sequential_id,
-#                      UNIQUE constraint on sequential_id within concurrent_burrow_id scope
+#                      UNIQUE constraint on sequential_id within burrow_id scope
+#   DeadlockAlpha    - no options
+#   DeadlockBeta     - no options
 
 if ENV['DB'] == 'postgresql'
   class ConcurrencyTest < ActiveSupport::TestCase
     self.use_transactional_tests = false
 
+    Barrier = Struct.new(:size, :waiting, :mutex, :condition) do
+      def initialize(size)
+        super(size, 0, Mutex.new, ConditionVariable.new)
+      end
+
+      def wait
+        mutex.synchronize do
+          self.waiting += 1
+          if waiting < size
+            condition.wait(mutex)
+          else
+            condition.broadcast
+          end
+        end
+      end
+    end
+
     def setup
-      ConcurrentBadger.delete_all
+      cleanup_models.each(&:delete_all)
     end
 
     def teardown
-      ConcurrentBadger.delete_all
+      cleanup_models.each(&:delete_all)
     end
 
     test "creates records concurrently without data races" do
-      Thread.abort_on_exception = true
       range = (1..50)
 
-      threads = []
-      range.each do
-        threads << Thread.new do
-          ConcurrentBadger.create!(burrow_id: 1)
+      threads = range.map do
+        Thread.new do
+          with_connection do
+            ConcurrentBadger.create!(burrow_id: 1)
+          end
         end
       end
 
       threads.each(&:join)
 
-      sequential_ids = ConcurrentBadger.pluck(:sequential_id)
+      sequential_ids = ConcurrentBadger.order(:sequential_id).pluck(:sequential_id)
       assert_equal range.to_a, sequential_ids
     end
 
@@ -58,7 +77,7 @@ if ENV['DB'] == 'postgresql'
         end
       end
 
-      sequential_ids = ConcurrentBadger.pluck(:sequential_id)
+      sequential_ids = ConcurrentBadger.order(:sequential_id).pluck(:sequential_id)
       assert_equal range.to_a, sequential_ids
     end
 
@@ -75,8 +94,85 @@ if ENV['DB'] == 'postgresql'
         end
       end
 
-      sequential_ids = ConcurrentBadger.pluck(:sequential_id)
+      sequential_ids = ConcurrentBadger.order(:sequential_id).pluck(:sequential_id)
       assert_equal range.to_a, sequential_ids
+    end
+
+    test "does not deadlock when transactions update different tables before allocating sequences" do
+      alpha = DeadlockAlpha.create!(name: "seed alpha")
+      beta = DeadlockBeta.create!(name: "seed beta")
+      barrier = Barrier.new(2)
+      errors = Queue.new
+
+      threads = [
+        Thread.new do
+          with_connection do
+            DeadlockAlpha.transaction do
+              DeadlockBeta.find(beta.id).update!(name: "updated by alpha transaction")
+              barrier.wait
+              DeadlockAlpha.create!(name: "created by alpha transaction")
+            end
+          end
+        rescue => error
+          errors << error
+        end,
+        Thread.new do
+          with_connection do
+            DeadlockBeta.transaction do
+              DeadlockAlpha.find(alpha.id).update!(name: "updated by beta transaction")
+              barrier.wait
+              DeadlockBeta.create!(name: "created by beta transaction")
+            end
+          end
+        rescue => error
+          errors << error
+        end
+      ]
+
+      threads.each(&:join)
+
+      assert_thread_errors!(errors)
+      assert_equal [1, 2], DeadlockAlpha.order(:sequential_id).pluck(:sequential_id)
+      assert_equal [1, 2], DeadlockBeta.order(:sequential_id).pluck(:sequential_id)
+    end
+
+    test "allocates independent sequences concurrently for separate scopes" do
+      barrier = Barrier.new(2)
+      errors = Queue.new
+
+      threads = [1, 2].map do |burrow_id|
+        Thread.new do
+          with_connection do
+            barrier.wait
+            10.times { ConcurrentBadger.create!(burrow_id: burrow_id) }
+          end
+        rescue => error
+          errors << error
+        end
+      end
+
+      threads.each(&:join)
+
+      assert_thread_errors!(errors)
+      assert_equal (1..10).to_a, ConcurrentBadger.where(burrow_id: 1).order(:sequential_id).pluck(:sequential_id)
+      assert_equal (1..10).to_a, ConcurrentBadger.where(burrow_id: 2).order(:sequential_id).pluck(:sequential_id)
+    end
+
+  private
+
+    def cleanup_models
+      [ConcurrentBadger, DeadlockAlpha, DeadlockBeta]
+    end
+
+    def with_connection(&block)
+      ActiveRecord::Base.connection_pool.with_connection(&block)
+    end
+
+    def assert_thread_errors!(errors)
+      return if errors.empty?
+
+      error = errors.pop
+      flunk("#{error.class}: #{error.message}\n#{Array(error.backtrace).join("\n")}")
     end
   end
 end

--- a/test/dummy/app/models/deadlock_alpha.rb
+++ b/test/dummy/app/models/deadlock_alpha.rb
@@ -1,0 +1,3 @@
+class DeadlockAlpha < ActiveRecord::Base
+  acts_as_sequenced
+end

--- a/test/dummy/app/models/deadlock_beta.rb
+++ b/test/dummy/app/models/deadlock_beta.rb
@@ -1,0 +1,3 @@
+class DeadlockBeta < ActiveRecord::Base
+  acts_as_sequenced
+end

--- a/test/dummy/db/migrate/20260316120000_create_deadlock_models.rb
+++ b/test/dummy/db/migrate/20260316120000_create_deadlock_models.rb
@@ -1,0 +1,19 @@
+class CreateDeadlockModels < ActiveRecord::Migration[4.2]
+  def change
+    create_table :deadlock_alphas do |t|
+      t.string :name
+      t.integer :sequential_id, null: false
+      t.timestamps null: false
+    end
+
+    add_index :deadlock_alphas, :sequential_id, unique: true
+
+    create_table :deadlock_beta do |t|
+      t.string :name
+      t.integer :sequential_id, null: false
+      t.timestamps null: false
+    end
+
+    add_index :deadlock_beta, :sequential_id, unique: true
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_16_124804) do
+ActiveRecord::Schema.define(version: 2026_03_16_120000) do
 
   create_table "accounts", force: :cascade do |t|
     t.string "name"
@@ -48,6 +48,22 @@ ActiveRecord::Schema.define(version: 2019_02_16_124804) do
     t.integer "sequential_id", null: false
     t.integer "burrow_id"
     t.index ["sequential_id", "burrow_id"], name: "unique_concurrent", unique: true
+  end
+
+  create_table "deadlock_alphas", force: :cascade do |t|
+    t.string "name"
+    t.integer "sequential_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["sequential_id"], name: "index_deadlock_alphas_on_sequential_id", unique: true
+  end
+
+  create_table "deadlock_beta", force: :cascade do |t|
+    t.string "name"
+    t.integer "sequential_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["sequential_id"], name: "index_deadlock_beta_on_sequential_id", unique: true
   end
 
   create_table "doppelgangers", force: :cascade do |t|


### PR DESCRIPTION
## Summary
- Replace the PostgreSQL `LOCK TABLE ... IN EXCLUSIVE MODE` sequence lock with transaction-scoped advisory locks
- Key PostgreSQL lock acquisition by table, sequenced column, and resolved scope values so unrelated sequences no longer serialize together
- Add PostgreSQL concurrency regression coverage for cross-table deadlocks and separate-scope allocation
- Add dummy deadlock models and migration fixtures for the new concurrency tests

## Why
The current PostgreSQL path takes an exclusive table lock during sequence allocation. That is broader than necessary and can deadlock when one transaction updates one table and then creates a sequenced record in another table while another transaction does the inverse.

## Changes
### fix(postgresql): replace sequence table locks with advisory locks
- **What:** Swap the PostgreSQL lock path in `Sequenced::Generator` to `pg_advisory_xact_lock`, derive deterministic two-integer lock keys from the sequence identity, and reuse shared scope-resolution helpers for both query building and lock-key derivation.
- **Why:** Avoid cross-table deadlocks without redesigning the allocator or changing public API behavior.
- **What:** Add a PostgreSQL-only regression test that reproduces the deadlock shape across two tables, plus a concurrency test that proves separate scopes still allocate independently.
- **Why:** The existing test coverage only checked duplicate prevention on one table and would not catch the actual deadlock regression.

## Testing
- [x] `ruby -c lib/sequenced/generator.rb`
- [x] `ruby -c test/concurrency_test.rb`
- [x] `ruby -c test/dummy/app/models/deadlock_alpha.rb`
- [x] `ruby -c test/dummy/app/models/deadlock_beta.rb`
- [x] `ruby -c test/dummy/db/migrate/20260316120000_create_deadlock_models.rb`
- [x] `ruby -c test/dummy/db/schema.rb`
- [x] `git diff --check`
- [ ] `DB=postgresql bundle exec rake test` currently blocked because `bundle install` fails building `sqlite3 1.3.13` on the available Ruby 4.0.1 toolchain
- [ ] `bundle exec rake test` currently blocked for the same dependency reason

## Risk & Rollout
- **Risk:** Medium. This changes PostgreSQL concurrency behavior in the sequence allocator, but keeps the existing allocation algorithm and adds regression coverage around the deadlock scenario.
- **Rollback:** Revert commit `07fbe8a`.
- **Monitoring:** Watch PostgreSQL consumers for `ActiveRecord::Deadlocked` exceptions during sequenced creates and for duplicate sequence allocations within a scope.